### PR TITLE
Phase 3: B+Tree 인덱스

### DIFF
--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -1,0 +1,519 @@
+use crate::buffer::{BufferPool, BufferPoolError};
+use crate::page::{PageId, PageType};
+#[cfg(test)]
+use crate::page::FileManager;
+use super::key::Key;
+use super::node::{BTreeNode, LeafNode, InternalNode};
+
+/// 한 리프 노드의 최대 엔트리 수
+/// 실제 InnoDB는 페이지 크기와 레코드 크기에 따라 동적으로 결정되지만,
+/// 학습 목적으로 고정값을 사용한다.
+const MAX_LEAF_ENTRIES: usize = 4;
+
+/// 한 내부 노드의 최대 엔트리 수
+const MAX_INTERNAL_ENTRIES: usize = 4;
+
+/// 디스크 기반 B+Tree 인덱스
+///
+/// InnoDB에서 테이블 = Clustered Index = B+Tree.
+/// 모든 행 데이터가 리프 노드에 저장된다.
+pub struct BTree {
+    root_page_no: u32,
+    buffer_pool: BufferPool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BTreeError {
+    #[error("buffer pool error: {0}")]
+    BufferPool(#[from] BufferPoolError),
+    #[error("page data error: {0}")]
+    PageData(#[from] crate::page::PageError),
+}
+
+impl BTree {
+    /// 새 B+Tree 생성 (빈 리프 노드를 root로)
+    pub fn new(buffer_pool: BufferPool) -> Result<Self, BTreeError> {
+        let root_page_no;
+
+        // root 페이지 할당 및 빈 리프 노드로 초기화
+        {
+            let guard = buffer_pool.new_page(PageType::Index)?;
+            root_page_no = guard.read(|page| page.page_no());
+
+            let node = BTreeNode::new_leaf();
+            let bytes = node.serialize();
+            guard.write(|page| {
+                page.write_data(0, &bytes).unwrap();
+            });
+        }
+
+        Ok(Self {
+            root_page_no,
+            buffer_pool,
+        })
+    }
+
+    /// 키로 값을 검색
+    pub fn search(&self, key: &Key) -> Result<Option<Vec<u8>>, BTreeError> {
+        let leaf_page_no = self.find_leaf(key)?;
+        let guard = self.buffer_pool.fetch_page(PageId::new(0, leaf_page_no))?;
+
+        let result = guard.read(|page| {
+            let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+            let node = BTreeNode::deserialize(data);
+            if let BTreeNode::Leaf(leaf) = node {
+                leaf.search(key).map(|v| v.to_vec())
+            } else {
+                None
+            }
+        });
+
+        Ok(result)
+    }
+
+    /// key-value 쌍 삽입
+    pub fn insert(&mut self, key: Key, value: Vec<u8>) -> Result<(), BTreeError> {
+        let result = self.insert_recursive(self.root_page_no, key, value)?;
+
+        // 루트가 분할되었으면 새 루트 생성
+        if let Some((split_key, new_page_no)) = result {
+            let old_root = self.root_page_no;
+
+            // 새 루트 페이지 할당
+            let guard = self.buffer_pool.new_page(PageType::Index)?;
+            let new_root_page_no = guard.read(|page| page.page_no());
+
+            let mut new_root = InternalNode {
+                first_child_page_no: old_root,
+                entries: Vec::new(),
+            };
+            new_root.insert_entry(split_key, new_page_no);
+
+            let bytes = BTreeNode::Internal(new_root).serialize();
+            guard.write(|page| {
+                page.write_data(0, &bytes).unwrap();
+            });
+
+            self.root_page_no = new_root_page_no;
+        }
+
+        Ok(())
+    }
+
+    /// 범위 검색: start_key 이상 end_key 이하의 모든 엔트리 반환
+    pub fn range_scan(&self, start_key: &Key, end_key: &Key) -> Result<Vec<(Key, Vec<u8>)>, BTreeError> {
+        let mut results = Vec::new();
+        let mut current_page_no = self.find_leaf(start_key)?;
+
+        'outer: loop {
+            let (entries, next_page_no) = {
+                let guard = self.buffer_pool.fetch_page(PageId::new(0, current_page_no))?;
+                guard.read(|page| {
+                    let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+                    let node = BTreeNode::deserialize(data);
+                    if let BTreeNode::Leaf(leaf) = node {
+                        let entries: Vec<(Key, Vec<u8>)> = leaf.entries.iter()
+                            .filter(|e| e.key >= *start_key && e.key <= *end_key)
+                            .map(|e| (e.key.clone(), e.value.clone()))
+                            .collect();
+                        let next = leaf.next_page_no;
+                        (entries, next)
+                    } else {
+                        (Vec::new(), None)
+                    }
+                })
+            };
+
+            for entry in entries {
+                if entry.0 > *end_key {
+                    break 'outer;
+                }
+                results.push(entry);
+            }
+
+            match next_page_no {
+                Some(next) => {
+                    // 다음 리프의 첫 키가 end_key를 넘으면 중단
+                    current_page_no = next;
+                }
+                None => break,
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// root에서 리프까지 탐색하여 해당 키가 속하는 리프 페이지 번호 반환
+    fn find_leaf(&self, key: &Key) -> Result<u32, BTreeError> {
+        let mut current_page_no = self.root_page_no;
+
+        loop {
+            let guard = self.buffer_pool.fetch_page(PageId::new(0, current_page_no))?;
+            let next = guard.read(|page| {
+                let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+                let node = BTreeNode::deserialize(data);
+                match node {
+                    BTreeNode::Leaf(_) => None, // 리프에 도착
+                    BTreeNode::Internal(internal) => Some(internal.find_child(key)),
+                }
+            });
+
+            match next {
+                Some(child_page_no) => current_page_no = child_page_no,
+                None => return Ok(current_page_no),
+            }
+        }
+    }
+
+    /// 재귀적 삽입. 분할이 발생하면 (분할 키, 새 페이지 번호)를 반환.
+    fn insert_recursive(
+        &mut self,
+        page_no: u32,
+        key: Key,
+        value: Vec<u8>,
+    ) -> Result<Option<(Key, u32)>, BTreeError> {
+        let guard = self.buffer_pool.fetch_page(PageId::new(0, page_no))?;
+        let is_leaf = guard.read(|page| {
+            let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+            BTreeNode::deserialize(data).is_leaf()
+        });
+
+        if is_leaf {
+            // 리프 노드에 삽입
+            let needs_split = guard.read(|page| {
+                let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+                if let BTreeNode::Leaf(leaf) = BTreeNode::deserialize(data) {
+                    // 이미 같은 키가 있으면 업데이트이므로 분할 불필요
+                    let exists = leaf.search(&key).is_some();
+                    !exists && leaf.len() >= MAX_LEAF_ENTRIES
+                } else {
+                    false
+                }
+            });
+
+            if needs_split {
+                // 분할 필요 — 먼저 현재 노드에 삽입 후 분할
+                drop(guard);
+                return self.split_leaf(page_no, key, value);
+            }
+
+            // 분할 불필요 — 그냥 삽입
+            guard.write(|page| {
+                let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+                let mut node = BTreeNode::deserialize(data);
+                if let BTreeNode::Leaf(ref mut leaf) = node {
+                    leaf.insert(key, value);
+                }
+                let bytes = node.serialize();
+                page.write_data(0, &bytes).unwrap();
+            });
+
+            Ok(None)
+        } else {
+            // 내부 노드 — 자식으로 재귀
+            let child_page_no = guard.read(|page| {
+                let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+                if let BTreeNode::Internal(internal) = BTreeNode::deserialize(data) {
+                    internal.find_child(&key)
+                } else {
+                    unreachable!()
+                }
+            });
+            drop(guard);
+
+            let child_result = self.insert_recursive(child_page_no, key, value)?;
+
+            // 자식이 분할되었으면 이 노드에 새 엔트리 추가
+            if let Some((split_key, new_child_page_no)) = child_result {
+                let guard = self.buffer_pool.fetch_page(PageId::new(0, page_no))?;
+
+                let needs_split = guard.read(|page| {
+                    let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+                    if let BTreeNode::Internal(internal) = BTreeNode::deserialize(data) {
+                        internal.entries.len() >= MAX_INTERNAL_ENTRIES
+                    } else {
+                        false
+                    }
+                });
+
+                if needs_split {
+                    drop(guard);
+                    return self.split_internal(page_no, split_key, new_child_page_no);
+                }
+
+                guard.write(|page| {
+                    let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+                    let mut node = BTreeNode::deserialize(data);
+                    if let BTreeNode::Internal(ref mut internal) = node {
+                        internal.insert_entry(split_key, new_child_page_no);
+                    }
+                    let bytes = node.serialize();
+                    page.write_data(0, &bytes).unwrap();
+                });
+
+                Ok(None)
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    /// 리프 노드 분할
+    ///
+    /// 1. 현재 리프에 새 엔트리를 삽입한 상태에서 절반을 새 페이지로 이동
+    /// 2. prev/next 포인터 갱신
+    /// 3. (분할 키, 새 페이지 번호) 반환
+    fn split_leaf(
+        &mut self,
+        page_no: u32,
+        key: Key,
+        value: Vec<u8>,
+    ) -> Result<Option<(Key, u32)>, BTreeError> {
+        // 현재 리프의 모든 엔트리를 읽어서 새 키 포함한 전체 목록 만들기
+        let guard = self.buffer_pool.fetch_page(PageId::new(0, page_no))?;
+        let (mut all_entries, old_next) = guard.read(|page| {
+            let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+            if let BTreeNode::Leaf(mut leaf) = BTreeNode::deserialize(data) {
+                leaf.insert(key, value);
+                let next = leaf.next_page_no;
+                (leaf.entries, next)
+            } else {
+                unreachable!()
+            }
+        });
+
+        // 절반으로 분할
+        let mid = all_entries.len() / 2;
+        let right_entries: Vec<_> = all_entries.drain(mid..).collect();
+        let left_entries = all_entries;
+        let split_key = right_entries[0].key.clone();
+
+        // 새 리프 페이지 할당
+        let new_guard = self.buffer_pool.new_page(PageType::Index)?;
+        let new_page_no = new_guard.read(|page| page.page_no());
+
+        // 새 리프 (오른쪽) 작성
+        let right_leaf = BTreeNode::Leaf(LeafNode {
+            entries: right_entries,
+            prev_page_no: Some(page_no),
+            next_page_no: old_next,
+        });
+        let bytes = right_leaf.serialize();
+        new_guard.write(|page| {
+            page.write_data(0, &bytes).unwrap();
+        });
+        drop(new_guard);
+
+        // 기존 리프 (왼쪽) 갱신
+        let left_leaf = BTreeNode::Leaf(LeafNode {
+            entries: left_entries,
+            prev_page_no: {
+                guard.read(|page| {
+                    let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+                    if let BTreeNode::Leaf(leaf) = BTreeNode::deserialize(data) {
+                        leaf.prev_page_no
+                    } else {
+                        None
+                    }
+                })
+            },
+            next_page_no: Some(new_page_no),
+        });
+        let bytes = left_leaf.serialize();
+        guard.write(|page| {
+            page.write_data(0, &bytes).unwrap();
+        });
+        drop(guard);
+
+        // old_next의 prev 포인터 갱신
+        if let Some(next_page_no) = old_next {
+            let next_guard = self.buffer_pool.fetch_page(PageId::new(0, next_page_no))?;
+            next_guard.write(|page| {
+                let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+                if let BTreeNode::Leaf(mut leaf) = BTreeNode::deserialize(data) {
+                    leaf.prev_page_no = Some(new_page_no);
+                    let bytes = BTreeNode::Leaf(leaf).serialize();
+                    page.write_data(0, &bytes).unwrap();
+                }
+            });
+        }
+
+        Ok(Some((split_key, new_page_no)))
+    }
+
+    /// 내부 노드 분할
+    fn split_internal(
+        &mut self,
+        page_no: u32,
+        new_key: Key,
+        new_child_page_no: u32,
+    ) -> Result<Option<(Key, u32)>, BTreeError> {
+        let guard = self.buffer_pool.fetch_page(PageId::new(0, page_no))?;
+        let (first_child, mut all_entries) = guard.read(|page| {
+            let data = page.read_data(0, crate::page::Page::DATA_END - crate::page::Page::DATA_START).unwrap();
+            if let BTreeNode::Internal(mut internal) = BTreeNode::deserialize(data) {
+                internal.insert_entry(new_key, new_child_page_no);
+                (internal.first_child_page_no, internal.entries)
+            } else {
+                unreachable!()
+            }
+        });
+
+        let mid = all_entries.len() / 2;
+        let right_entries: Vec<_> = all_entries.drain(mid + 1..).collect();
+        let split_entry = all_entries.pop().unwrap(); // mid번째가 상위로 올라감
+        let left_entries = all_entries;
+
+        // 새 내부 노드 (오른쪽)
+        let new_guard = self.buffer_pool.new_page(PageType::Index)?;
+        let new_page_no = new_guard.read(|page| page.page_no());
+
+        let right_internal = BTreeNode::Internal(InternalNode {
+            first_child_page_no: split_entry.child_page_no,
+            entries: right_entries,
+        });
+        let bytes = right_internal.serialize();
+        new_guard.write(|page| {
+            page.write_data(0, &bytes).unwrap();
+        });
+        drop(new_guard);
+
+        // 기존 내부 노드 (왼쪽) 갱신
+        let left_internal = BTreeNode::Internal(InternalNode {
+            first_child_page_no: first_child,
+            entries: left_entries,
+        });
+        let bytes = left_internal.serialize();
+        guard.write(|page| {
+            page.write_data(0, &bytes).unwrap();
+        });
+        drop(guard);
+
+        Ok(Some((split_entry.key, new_page_no)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    fn setup_btree(pool_size: usize) -> (BTree, NamedTempFile) {
+        let tmp = NamedTempFile::new().unwrap();
+        let fm = FileManager::open_or_create(0, tmp.path()).unwrap();
+        let pool = BufferPool::new(pool_size, fm);
+        let btree = BTree::new(pool).unwrap();
+        (btree, tmp)
+    }
+
+    #[test]
+    fn test_insert_and_search() {
+        let (mut btree, _tmp) = setup_btree(100);
+
+        btree.insert(Key::from_u64(10), b"ten".to_vec()).unwrap();
+        btree.insert(Key::from_u64(20), b"twenty".to_vec()).unwrap();
+        btree.insert(Key::from_u64(5), b"five".to_vec()).unwrap();
+
+        assert_eq!(btree.search(&Key::from_u64(10)).unwrap(), Some(b"ten".to_vec()));
+        assert_eq!(btree.search(&Key::from_u64(20)).unwrap(), Some(b"twenty".to_vec()));
+        assert_eq!(btree.search(&Key::from_u64(5)).unwrap(), Some(b"five".to_vec()));
+        assert_eq!(btree.search(&Key::from_u64(99)).unwrap(), None);
+    }
+
+    #[test]
+    fn test_update_existing_key() {
+        let (mut btree, _tmp) = setup_btree(100);
+
+        btree.insert(Key::from_u64(10), b"old".to_vec()).unwrap();
+        btree.insert(Key::from_u64(10), b"new".to_vec()).unwrap();
+
+        assert_eq!(btree.search(&Key::from_u64(10)).unwrap(), Some(b"new".to_vec()));
+    }
+
+    #[test]
+    fn test_leaf_split() {
+        let (mut btree, _tmp) = setup_btree(100);
+
+        // MAX_LEAF_ENTRIES = 4이므로 5번째 삽입에서 분할 발생
+        for i in 1..=6 {
+            let val = format!("val-{}", i);
+            btree.insert(Key::from_u64(i), val.into_bytes()).unwrap();
+        }
+
+        // 분할 후에도 모든 키 검색 가능
+        for i in 1..=6 {
+            let expected = format!("val-{}", i);
+            assert_eq!(
+                btree.search(&Key::from_u64(i)).unwrap(),
+                Some(expected.into_bytes())
+            );
+        }
+    }
+
+    #[test]
+    fn test_many_inserts() {
+        let (mut btree, _tmp) = setup_btree(200);
+
+        // 여러 번의 분할을 유발하는 대량 삽입
+        for i in 1..=50 {
+            let val = format!("value-{}", i);
+            btree.insert(Key::from_u64(i), val.into_bytes()).unwrap();
+        }
+
+        // 모든 키가 올바르게 검색되는지 확인
+        for i in 1..=50 {
+            let expected = format!("value-{}", i);
+            assert_eq!(
+                btree.search(&Key::from_u64(i)).unwrap(),
+                Some(expected.into_bytes()),
+                "key {} not found",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_reverse_order_inserts() {
+        let (mut btree, _tmp) = setup_btree(200);
+
+        // 역순 삽입
+        for i in (1..=20).rev() {
+            let val = format!("val-{}", i);
+            btree.insert(Key::from_u64(i), val.into_bytes()).unwrap();
+        }
+
+        for i in 1..=20 {
+            let expected = format!("val-{}", i);
+            assert_eq!(
+                btree.search(&Key::from_u64(i)).unwrap(),
+                Some(expected.into_bytes())
+            );
+        }
+    }
+
+    #[test]
+    fn test_range_scan() {
+        let (mut btree, _tmp) = setup_btree(100);
+
+        for i in 1..=10 {
+            let val = format!("v{}", i);
+            btree.insert(Key::from_u64(i), val.into_bytes()).unwrap();
+        }
+
+        let results = btree.range_scan(&Key::from_u64(3), &Key::from_u64(7)).unwrap();
+        let keys: Vec<u64> = results.iter().map(|(k, _)| k.as_u64().unwrap()).collect();
+        assert_eq!(keys, vec![3, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn test_range_scan_all() {
+        let (mut btree, _tmp) = setup_btree(100);
+
+        for i in 1..=10 {
+            btree.insert(Key::from_u64(i), vec![i as u8]).unwrap();
+        }
+
+        let results = btree.range_scan(&Key::from_u64(1), &Key::from_u64(10)).unwrap();
+        assert_eq!(results.len(), 10);
+    }
+}

--- a/src/btree/key.rs
+++ b/src/btree/key.rs
@@ -1,0 +1,119 @@
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::io::Cursor;
+
+/// B+Tree 검색 키
+///
+/// InnoDB에서 Clustered Index의 키는 Primary Key이다.
+/// 단순화를 위해 가변 길이 바이트 배열로 표현한다.
+/// Big Endian으로 저장하므로 바이트 단위 비교가 곧 논리적 비교와 같다.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Key(Vec<u8>);
+
+impl Key {
+    pub fn new(data: Vec<u8>) -> Self {
+        Self(data)
+    }
+
+    /// u64 값으로부터 키 생성 (Big Endian 8바이트)
+    pub fn from_u64(value: u64) -> Self {
+        let mut buf = Vec::with_capacity(8);
+        buf.write_u64::<BigEndian>(value).unwrap();
+        Self(buf)
+    }
+
+    /// u64 값으로 변환
+    pub fn as_u64(&self) -> Option<u64> {
+        if self.0.len() != 8 {
+            return None;
+        }
+        let mut cursor = Cursor::new(&self.0);
+        Some(cursor.read_u64::<BigEndian>().unwrap())
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// 바이트 배열로부터 키 생성
+    pub fn from_bytes(data: &[u8]) -> Self {
+        Self(data.to_vec())
+    }
+
+    /// 직렬화된 크기 (2바이트 길이 접두사 + 데이터)
+    pub fn serialized_size(&self) -> usize {
+        2 + self.0.len()
+    }
+
+    /// 바이트 버퍼에 직렬화 (길이 접두사 + 데이터)
+    pub fn serialize_into(&self, buf: &mut Vec<u8>) {
+        buf.write_u16::<BigEndian>(self.0.len() as u16).unwrap();
+        buf.extend_from_slice(&self.0);
+    }
+
+    /// 바이트 슬라이스에서 역직렬화, 소비한 바이트 수 반환
+    pub fn deserialize_from(data: &[u8]) -> (Self, usize) {
+        let mut cursor = Cursor::new(data);
+        let len = cursor.read_u16::<BigEndian>().unwrap() as usize;
+        let key = Self(data[2..2 + len].to_vec());
+        (key, 2 + len)
+    }
+}
+
+impl PartialOrd for Key {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Key {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl std::fmt::Display for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(v) = self.as_u64() {
+            write!(f, "Key({})", v)
+        } else {
+            write!(f, "Key({:?})", self.0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_u64_key_ordering() {
+        let k1 = Key::from_u64(1);
+        let k2 = Key::from_u64(2);
+        let k100 = Key::from_u64(100);
+
+        assert!(k1 < k2);
+        assert!(k2 < k100);
+        assert_eq!(k1, Key::from_u64(1));
+    }
+
+    #[test]
+    fn test_u64_roundtrip() {
+        let key = Key::from_u64(42);
+        assert_eq!(key.as_u64(), Some(42));
+    }
+
+    #[test]
+    fn test_serialize_deserialize() {
+        let key = Key::from_u64(12345);
+        let mut buf = Vec::new();
+        key.serialize_into(&mut buf);
+
+        let (decoded, consumed) = Key::deserialize_from(&buf);
+        assert_eq!(decoded, key);
+        assert_eq!(consumed, key.serialized_size());
+    }
+}

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -1,0 +1,7 @@
+mod key;
+mod node;
+mod btree;
+
+pub use key::Key;
+pub use node::{BTreeNode, LeafEntry, InternalEntry};
+pub use btree::BTree;

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -1,0 +1,383 @@
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::io::Cursor;
+
+use super::key::Key;
+
+/// 리프 노드의 엔트리: key → value
+#[derive(Debug, Clone)]
+pub struct LeafEntry {
+    pub key: Key,
+    pub value: Vec<u8>,
+}
+
+/// 내부 노드의 엔트리: key + 자식 페이지 번호
+#[derive(Debug, Clone)]
+pub struct InternalEntry {
+    pub key: Key,
+    pub child_page_no: u32,
+}
+
+/// B+Tree 노드
+///
+/// InnoDB에서 B+Tree의 모든 노드는 하나의 페이지에 저장된다.
+/// 노드 타입에 따라 내부 노드 또는 리프 노드로 구분한다.
+#[derive(Debug)]
+pub enum BTreeNode {
+    Internal(InternalNode),
+    Leaf(LeafNode),
+}
+
+/// 내부 노드
+///
+/// n개의 키와 n+1개의 자식 포인터를 가진다.
+/// children[i]는 keys[i-1] 이상 keys[i] 미만인 키를 포함하는 서브트리.
+///
+/// ```text
+///        [  key0  |  key1  ]
+///       /         |         \
+/// child0     child1       child2
+/// (< key0)  (≥key0,<key1) (≥ key1)
+/// ```
+#[derive(Debug)]
+pub struct InternalNode {
+    /// 첫 번째 자식 (가장 왼쪽, keys[0]보다 작은 키들)
+    pub first_child_page_no: u32,
+    /// (key, child_page_no) 쌍의 목록
+    pub entries: Vec<InternalEntry>,
+}
+
+/// 리프 노드
+///
+/// 실제 데이터(key-value 쌍)가 저장되는 노드.
+/// prev/next로 리프 노드끼리 양방향 연결되어 범위 스캔을 지원한다.
+///
+/// ```text
+/// [Leaf prev=2] ←→ [Leaf (this)] ←→ [Leaf next=5]
+///   key1: val1       key3: val3        key5: val5
+///   key2: val2       key4: val4        key6: val6
+/// ```
+#[derive(Debug)]
+pub struct LeafNode {
+    pub entries: Vec<LeafEntry>,
+    pub prev_page_no: Option<u32>,
+    pub next_page_no: Option<u32>,
+}
+
+/// 노드 타입 마커 (직렬화용)
+const NODE_TYPE_INTERNAL: u8 = 1;
+const NODE_TYPE_LEAF: u8 = 2;
+
+/// prev/next가 없음을 나타내는 센티넬 값
+const PAGE_NO_NONE: u32 = u32::MAX;
+
+impl BTreeNode {
+    /// 빈 리프 노드 생성
+    pub fn new_leaf() -> Self {
+        BTreeNode::Leaf(LeafNode {
+            entries: Vec::new(),
+            prev_page_no: None,
+            next_page_no: None,
+        })
+    }
+
+    /// 빈 내부 노드 생성
+    pub fn new_internal(first_child_page_no: u32) -> Self {
+        BTreeNode::Internal(InternalNode {
+            first_child_page_no,
+            entries: Vec::new(),
+        })
+    }
+
+    pub fn is_leaf(&self) -> bool {
+        matches!(self, BTreeNode::Leaf(_))
+    }
+
+    /// 바이트 배열로 직렬화 (페이지의 데이터 영역에 저장용)
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+
+        match self {
+            BTreeNode::Leaf(leaf) => {
+                buf.push(NODE_TYPE_LEAF);
+
+                // prev/next 페이지 번호
+                buf.write_u32::<BigEndian>(
+                    leaf.prev_page_no.unwrap_or(PAGE_NO_NONE),
+                ).unwrap();
+                buf.write_u32::<BigEndian>(
+                    leaf.next_page_no.unwrap_or(PAGE_NO_NONE),
+                ).unwrap();
+
+                // 엔트리 수
+                buf.write_u16::<BigEndian>(leaf.entries.len() as u16).unwrap();
+
+                // 각 엔트리
+                for entry in &leaf.entries {
+                    entry.key.serialize_into(&mut buf);
+                    buf.write_u16::<BigEndian>(entry.value.len() as u16).unwrap();
+                    buf.extend_from_slice(&entry.value);
+                }
+            }
+            BTreeNode::Internal(internal) => {
+                buf.push(NODE_TYPE_INTERNAL);
+
+                // 첫 번째 자식
+                buf.write_u32::<BigEndian>(internal.first_child_page_no).unwrap();
+
+                // 엔트리 수
+                buf.write_u16::<BigEndian>(internal.entries.len() as u16).unwrap();
+
+                // 각 엔트리
+                for entry in &internal.entries {
+                    entry.key.serialize_into(&mut buf);
+                    buf.write_u32::<BigEndian>(entry.child_page_no).unwrap();
+                }
+            }
+        }
+
+        buf
+    }
+
+    /// 바이트 배열에서 역직렬화
+    pub fn deserialize(data: &[u8]) -> Self {
+        let node_type = data[0];
+        let mut offset = 1;
+
+        match node_type {
+            NODE_TYPE_LEAF => {
+                let mut cursor = Cursor::new(&data[offset..]);
+                let prev = cursor.read_u32::<BigEndian>().unwrap();
+                let next = cursor.read_u32::<BigEndian>().unwrap();
+                let count = cursor.read_u16::<BigEndian>().unwrap() as usize;
+                offset += 4 + 4 + 2;
+
+                let prev_page_no = if prev == PAGE_NO_NONE { None } else { Some(prev) };
+                let next_page_no = if next == PAGE_NO_NONE { None } else { Some(next) };
+
+                let mut entries = Vec::with_capacity(count);
+                for _ in 0..count {
+                    let (key, key_size) = Key::deserialize_from(&data[offset..]);
+                    offset += key_size;
+
+                    let mut cursor = Cursor::new(&data[offset..]);
+                    let val_len = cursor.read_u16::<BigEndian>().unwrap() as usize;
+                    offset += 2;
+
+                    let value = data[offset..offset + val_len].to_vec();
+                    offset += val_len;
+
+                    entries.push(LeafEntry { key, value });
+                }
+
+                BTreeNode::Leaf(LeafNode {
+                    entries,
+                    prev_page_no,
+                    next_page_no,
+                })
+            }
+            NODE_TYPE_INTERNAL => {
+                let mut cursor = Cursor::new(&data[offset..]);
+                let first_child = cursor.read_u32::<BigEndian>().unwrap();
+                let count = cursor.read_u16::<BigEndian>().unwrap() as usize;
+                offset += 4 + 2;
+
+                let mut entries = Vec::with_capacity(count);
+                for _ in 0..count {
+                    let (key, key_size) = Key::deserialize_from(&data[offset..]);
+                    offset += key_size;
+
+                    let mut cursor = Cursor::new(&data[offset..]);
+                    let child_page_no = cursor.read_u32::<BigEndian>().unwrap();
+                    offset += 4;
+
+                    entries.push(InternalEntry { key, child_page_no });
+                }
+
+                BTreeNode::Internal(InternalNode {
+                    first_child_page_no: first_child,
+                    entries,
+                })
+            }
+            _ => panic!("unknown node type: {}", node_type),
+        }
+    }
+}
+
+impl InternalNode {
+    /// 주어진 키가 속해야 하는 자식 페이지 번호를 찾는다.
+    ///
+    /// entries: [key0, key1, key2]
+    /// children: [first_child, child0, child1, child2]
+    ///
+    /// key < key0 → first_child
+    /// key0 ≤ key < key1 → child0
+    /// key1 ≤ key < key2 → child1
+    /// key2 ≤ key → child2
+    pub fn find_child(&self, key: &Key) -> u32 {
+        for entry in self.entries.iter().rev() {
+            if *key >= entry.key {
+                return entry.child_page_no;
+            }
+        }
+        self.first_child_page_no
+    }
+
+    /// 새로운 (key, child) 쌍을 정렬 위치에 삽입
+    pub fn insert_entry(&mut self, key: Key, child_page_no: u32) {
+        let pos = self.entries.partition_point(|e| e.key < key);
+        self.entries.insert(pos, InternalEntry { key, child_page_no });
+    }
+}
+
+impl LeafNode {
+    /// 키로 값을 검색
+    pub fn search(&self, key: &Key) -> Option<&[u8]> {
+        self.entries
+            .binary_search_by(|e| e.key.cmp(key))
+            .ok()
+            .map(|i| self.entries[i].value.as_slice())
+    }
+
+    /// key-value 쌍을 정렬 위치에 삽입. 이미 있으면 값을 업데이트.
+    pub fn insert(&mut self, key: Key, value: Vec<u8>) {
+        match self.entries.binary_search_by(|e| e.key.cmp(&key)) {
+            Ok(i) => {
+                // 이미 존재 → 값 업데이트
+                self.entries[i].value = value;
+            }
+            Err(i) => {
+                // 새로 삽입
+                self.entries.insert(i, LeafEntry { key, value });
+            }
+        }
+    }
+
+    /// 엔트리 수
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_leaf_insert_and_search() {
+        let mut leaf = LeafNode {
+            entries: Vec::new(),
+            prev_page_no: None,
+            next_page_no: None,
+        };
+
+        leaf.insert(Key::from_u64(10), b"hello".to_vec());
+        leaf.insert(Key::from_u64(5), b"world".to_vec());
+        leaf.insert(Key::from_u64(20), b"foo".to_vec());
+
+        assert_eq!(leaf.search(&Key::from_u64(5)), Some(b"world".as_slice()));
+        assert_eq!(leaf.search(&Key::from_u64(10)), Some(b"hello".as_slice()));
+        assert_eq!(leaf.search(&Key::from_u64(20)), Some(b"foo".as_slice()));
+        assert_eq!(leaf.search(&Key::from_u64(99)), None);
+    }
+
+    #[test]
+    fn test_leaf_update() {
+        let mut leaf = LeafNode {
+            entries: Vec::new(),
+            prev_page_no: None,
+            next_page_no: None,
+        };
+
+        leaf.insert(Key::from_u64(10), b"old".to_vec());
+        leaf.insert(Key::from_u64(10), b"new".to_vec());
+
+        assert_eq!(leaf.search(&Key::from_u64(10)), Some(b"new".as_slice()));
+        assert_eq!(leaf.len(), 1);
+    }
+
+    #[test]
+    fn test_leaf_sorted_order() {
+        let mut leaf = LeafNode {
+            entries: Vec::new(),
+            prev_page_no: None,
+            next_page_no: None,
+        };
+
+        leaf.insert(Key::from_u64(30), b"c".to_vec());
+        leaf.insert(Key::from_u64(10), b"a".to_vec());
+        leaf.insert(Key::from_u64(20), b"b".to_vec());
+
+        let keys: Vec<u64> = leaf.entries.iter()
+            .map(|e| e.key.as_u64().unwrap())
+            .collect();
+        assert_eq!(keys, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn test_internal_find_child() {
+        let internal = InternalNode {
+            first_child_page_no: 100,
+            entries: vec![
+                InternalEntry { key: Key::from_u64(10), child_page_no: 101 },
+                InternalEntry { key: Key::from_u64(20), child_page_no: 102 },
+                InternalEntry { key: Key::from_u64(30), child_page_no: 103 },
+            ],
+        };
+
+        assert_eq!(internal.find_child(&Key::from_u64(5)), 100);   // < 10
+        assert_eq!(internal.find_child(&Key::from_u64(10)), 101);  // >= 10, < 20
+        assert_eq!(internal.find_child(&Key::from_u64(15)), 101);  // >= 10, < 20
+        assert_eq!(internal.find_child(&Key::from_u64(20)), 102);  // >= 20, < 30
+        assert_eq!(internal.find_child(&Key::from_u64(30)), 103);  // >= 30
+        assert_eq!(internal.find_child(&Key::from_u64(99)), 103);  // >= 30
+    }
+
+    #[test]
+    fn test_serialize_deserialize_leaf() {
+        let mut leaf = LeafNode {
+            entries: Vec::new(),
+            prev_page_no: Some(3),
+            next_page_no: Some(7),
+        };
+        leaf.insert(Key::from_u64(10), b"hello".to_vec());
+        leaf.insert(Key::from_u64(20), b"world".to_vec());
+
+        let node = BTreeNode::Leaf(leaf);
+        let bytes = node.serialize();
+        let restored = BTreeNode::deserialize(&bytes);
+
+        if let BTreeNode::Leaf(leaf) = restored {
+            assert_eq!(leaf.prev_page_no, Some(3));
+            assert_eq!(leaf.next_page_no, Some(7));
+            assert_eq!(leaf.entries.len(), 2);
+            assert_eq!(leaf.search(&Key::from_u64(10)), Some(b"hello".as_slice()));
+            assert_eq!(leaf.search(&Key::from_u64(20)), Some(b"world".as_slice()));
+        } else {
+            panic!("expected leaf node");
+        }
+    }
+
+    #[test]
+    fn test_serialize_deserialize_internal() {
+        let node = BTreeNode::Internal(InternalNode {
+            first_child_page_no: 100,
+            entries: vec![
+                InternalEntry { key: Key::from_u64(10), child_page_no: 101 },
+                InternalEntry { key: Key::from_u64(20), child_page_no: 102 },
+            ],
+        });
+
+        let bytes = node.serialize();
+        let restored = BTreeNode::deserialize(&bytes);
+
+        if let BTreeNode::Internal(internal) = restored {
+            assert_eq!(internal.first_child_page_no, 100);
+            assert_eq!(internal.entries.len(), 2);
+            assert_eq!(internal.find_child(&Key::from_u64(5)), 100);
+            assert_eq!(internal.find_child(&Key::from_u64(15)), 101);
+            assert_eq!(internal.find_child(&Key::from_u64(25)), 102);
+        } else {
+            panic!("expected internal node");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod page;
 pub mod buffer;
+pub mod btree;

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -5,5 +5,5 @@ mod file_manager;
 
 pub use page_id::PageId;
 pub use page_type::PageType;
-pub use page::Page;
+pub use page::{Page, PageError, PAGE_SIZE};
 pub use file_manager::FileManager;


### PR DESCRIPTION
## Summary

InnoDB의 핵심 자료구조인 디스크 기반 B+Tree를 Rust로 구현. 검색, 삽입, 페이지 분할(리프/내부), 범위 스캔을 포함.

Closes #5

## 구현 내용

### Key (`key.rs`)

B+Tree 검색 키. 가변 길이 바이트 배열로 표현.

```rust
Key::from_u64(42)  // Big Endian 8바이트로 저장
// Big Endian이므로 바이트 단위 비교 == 논리적 크기 비교
```

- `Ord` trait 구현 — 바이트 사전순 비교가 곧 논리적 비교
- 직렬화: `[2바이트 길이][데이터]` 형식

### BTreeNode / LeafNode / InternalNode (`node.rs`)

**리프 노드:**
```
[type(1B)][prev(4B)][next(4B)][count(2B)][entries...]
  각 entry: [key_len(2B)][key][val_len(2B)][value]
```
- `binary_search_by`로 O(log n) 검색
- `insert()`는 정렬 위치에 삽입, 같은 키면 값 업데이트
- `prev_page_no` / `next_page_no`로 리프 간 양방향 연결

**내부 노드:**
```
[type(1B)][first_child(4B)][count(2B)][entries...]
  각 entry: [key_len(2B)][key][child_page_no(4B)]
```
- `find_child(key)`: 역순 순회로 해당 키가 속하는 자식 페이지 탐색
- n개 키 + (n+1)개 자식 포인터 구조

### BTree (`btree.rs`) — 핵심

**상수:**
- `MAX_LEAF_ENTRIES = 4` — 리프 분할 임계값 (학습용으로 작게 설정)
- `MAX_INTERNAL_ENTRIES = 4` — 내부 노드 분할 임계값

**검색 (`search`):**
```
find_leaf(key):  root → 내부 노드 순회 → 리프 도착
search(key):     find_leaf → 리프에서 binary_search
```

**삽입 (`insert`):**
```
insert_recursive(page_no, key, value):
  리프인가?
    YES → 공간 있으면 삽입, 없으면 split_leaf
    NO  → find_child → 재귀 → 자식이 분할했으면 이 노드에 엔트리 추가
                              → 이 노드도 꽉 찼으면 split_internal

루트가 분할되면 → 새 루트 생성 (트리 높이 +1)
```

**리프 분할 (`split_leaf`):**
```
Before: [1, 2, 3, 4] + insert(5)
After:  [1, 2] ←→ [3, 4, 5]  (split_key = 3)
         ↑ prev/next 포인터 갱신
```

**내부 노드 분할 (`split_internal`):**
```
Before: [10, 20, 30, 40] + insert(25)
        [10, 20, 25, 30, 40]
After:  [10, 20] | 25 올라감 | [30, 40]
         left     split_key    right
```

**범위 검색 (`range_scan`):**
```
find_leaf(start_key) → 리프에서 범위 내 엔트리 수집
→ next_page 따라 다음 리프로 이동 → 반복
→ end_key 초과 시 중단
```

### 실제 InnoDB와의 차이

| | 실제 InnoDB | 이 구현 |
|--|-----------|---------|
| 분할 임계값 | 페이지 크기/레코드 크기에 따라 동적 | 고정 4개 |
| 삭제/병합 | 지원 (merge threshold 기반) | 미지원 |
| Cursor | persistent cursor (위치 기억) | 없음 |
| 동시성 | latch coupling (트리 래치) | 단일 스레드 |
| Secondary Index | 별도 B+Tree (리프에 PK 저장) | 미지원 |
| Adaptive Hash Index | 자주 접근하는 페이지를 해시로 캐싱 | 없음 |

## Test plan

- [x] 키 정렬 순서 (Big Endian 바이트 비교)
- [x] 키 직렬화/역직렬화 라운드트립
- [x] 리프 노드 삽입/검색/업데이트
- [x] 리프 노드 정렬 유지 확인
- [x] 내부 노드 자식 탐색 (find_child)
- [x] 노드 직렬화/역직렬화 (리프, 내부 모두)
- [x] B+Tree 삽입 후 검색
- [x] 기존 키 업데이트
- [x] 리프 분할 후 모든 키 검색 가능
- [x] 대량 삽입 (50개) 후 전체 검색 검증
- [x] 역순 삽입 후 검색 검증
- [x] 범위 검색 (range_scan)
- [x] 전체 범위 검색

```
running 38 tests
test btree::key::tests::test_u64_key_ordering ... ok
test btree::key::tests::test_u64_roundtrip ... ok
test btree::key::tests::test_serialize_deserialize ... ok
test btree::node::tests::test_leaf_insert_and_search ... ok
test btree::node::tests::test_leaf_update ... ok
test btree::node::tests::test_leaf_sorted_order ... ok
test btree::node::tests::test_internal_find_child ... ok
test btree::node::tests::test_serialize_deserialize_leaf ... ok
test btree::node::tests::test_serialize_deserialize_internal ... ok
test btree::btree::tests::test_insert_and_search ... ok
test btree::btree::tests::test_update_existing_key ... ok
test btree::btree::tests::test_leaf_split ... ok
test btree::btree::tests::test_many_inserts ... ok
test btree::btree::tests::test_reverse_order_inserts ... ok
test btree::btree::tests::test_range_scan ... ok
test btree::btree::tests::test_range_scan_all ... ok
(+ Phase 1-2 tests 22개)

test result: ok. 38 passed; 0 failed;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)